### PR TITLE
Add per box settings (cf #41)

### DIFF
--- a/blog/templates/blog/content_form.html
+++ b/blog/templates/blog/content_form.html
@@ -1,13 +1,13 @@
 {% extends 'form-fullpage.html' %}
 {% load i18n %}
 
-{% block title %}
+{% block heading %}
     {% if content %}
         <h2>{% trans "Edit post" %} "{{ content }}"</h2>
     {% else %}
         <h2>{% trans "New post" %}</h2>
     {% endif %}
-{% endblock title %}
+{% endblock heading %}
 {% block col %}
     <input type="submit" value="{% trans 'submit' %}" />
 {% endblock col %}

--- a/ideasbox/conf/base.py
+++ b/ideasbox/conf/base.py
@@ -1,5 +1,5 @@
-"""
-Django settings for ideasbox project.
+# -*- coding: utf-8 -*-
+"""Django settings for ideasbox project.
 
 For more information on this file, see
 https://docs.djangoproject.com/en/1.7/topics/settings/
@@ -91,9 +91,9 @@ USE_L10N = True
 USE_TZ = True
 
 AVAILABLE_LANGUAGES = (
-    ('en', _('English')),
-    ('fr', _('French')),
-    ('ar', _('Arabic')),
+    ('en', 'English'),
+    ('fr', u'Français'),
+    ('ar', u'العربية'),
 )
 
 SUPPORTED_LANGUAGES = os.environ.get('SUPPORTED_LANGUAGES', 'fr en ar').split()
@@ -127,7 +127,7 @@ except KeyError:
         raise
 MEDIA_ROOT = os.path.join(STORAGE_ROOT, 'main')
 STATIC_ROOT = os.path.join(STORAGE_ROOT, 'static')  # TODO move out of backuped
-                                                    # storage
+                                                    # storage, cf #65.
 AUTH_USER_MODEL = 'ideasbox.DefaultUser'
 IDEASBOX_NAME = 'debugbox'
 
@@ -142,12 +142,12 @@ DATABASES = {
 }
 
 SERVICES = [
-    {'name': 'apache2', 'description': _('Daemon which provide web content')},
-    {'name': 'bind9', 'description': _('Daemon which provide local DNS')},
+    {'name': 'apache2', 'description': _('Daemon which provides web content')},
+    {'name': 'bind9', 'description': _('Daemon which provides local DNS')},
     {'name': 'kalite',
-        'description': _('Daemon which provide KhanAcademy on lan')},
+        'description': _('Daemon which provides KhanAcademy on lan')},
     {'name': 'kiwix',
-        'description': _('Daemon which provide Wikipedia on lan')},
+        'description': _('Daemon which provides Wikipedia on lan')},
     {'name': 'ntp', 'description': _('Net time protocol')},
     {'name': 'ssh',
         'description': _('Daemon used for distant connexion to server')},

--- a/ideasbox/conf/base.py
+++ b/ideasbox/conf/base.py
@@ -1,0 +1,154 @@
+"""
+Django settings for ideasbox project.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.7/topics/settings/
+
+For the full list of settings and their values, see
+https://docs.djangoproject.com/en/1.7/ref/settings/
+"""
+
+import os
+
+from django.utils.translation import ugettext_lazy as _
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+PROJECT_DIR = os.path.join(BASE_DIR, 'ideasbox')
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = '16exrv_@=2(za=oj$tj+l_^v#sbt83!=t#wz$s+1udfa04#vz!'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+TEMPLATE_DEBUG = True
+
+ALLOWED_HOSTS = []
+
+
+# Application definition
+
+INSTALLED_APPS = (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'serveradmin',
+    'ideasbox',
+    'blog',
+    'library',
+)
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
+
+TEMPLATE_CONTEXT_PROCESSORS = (
+    "django.contrib.auth.context_processors.auth",
+    "django.core.context_processors.debug",
+    "django.core.context_processors.i18n",
+    "django.core.context_processors.media",
+    "django.core.context_processors.static",
+    "django.core.context_processors.tz",
+    "django.contrib.messages.context_processors.messages",
+    "ideasbox.context_processors.settings"
+)
+
+ROOT_URLCONF = 'ideasbox.urls'
+
+WSGI_APPLICATION = 'ideasbox.wsgi.application'
+
+TEMPLATE_DIRS = (
+    os.path.join(PROJECT_DIR, 'templates'),
+)
+LOGIN_REDIRECT_URL = 'index'
+LOGIN_URL = 'login'
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.7/topics/i18n/
+
+LANGUAGE_CODE = 'en'
+
+TIME_ZONE = os.environ.get('TIME_ZONE', 'UTC')
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+AVAILABLE_LANGUAGES = (
+    ('en', _('English')),
+    ('fr', _('French')),
+    ('ar', _('Arabic')),
+)
+
+SUPPORTED_LANGUAGES = os.environ.get('SUPPORTED_LANGUAGES', 'fr en ar').split()
+LANGUAGES = []
+for code, label in AVAILABLE_LANGUAGES:
+    if code in SUPPORTED_LANGUAGES:
+        LANGUAGES.append((code, label))
+
+LOCALE_PATHS = (
+    os.path.join(BASE_DIR, 'locale'),
+)
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.7/howto/static-files/
+
+STATIC_URL = '/static/'
+MEDIA_URL = '/media/'
+
+
+# Ideas Box specifics
+try:
+    STORAGE_ROOT = os.environ['DATASTORAGE']
+except KeyError:
+    if DEBUG:
+        try:
+            os.makedirs('storage/main')
+        except OSError:
+            pass
+        STORAGE_ROOT = os.path.join(BASE_DIR, 'storage')
+    else:
+        raise
+MEDIA_ROOT = os.path.join(STORAGE_ROOT, 'main')
+STATIC_ROOT = os.path.join(STORAGE_ROOT, 'static')  # TODO move out of backuped
+                                                    # storage
+AUTH_USER_MODEL = 'ideasbox.DefaultUser'
+IDEASBOX_NAME = 'debugbox'
+
+# Database
+# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(MEDIA_ROOT, 'default.sqlite'),
+    }
+}
+
+SERVICES = [
+    {'name': 'apache2', 'description': _('Daemon which provide web content')},
+    {'name': 'bind9', 'description': _('Daemon which provide local DNS')},
+    {'name': 'kalite',
+        'description': _('Daemon which provide KhanAcademy on lan')},
+    {'name': 'kiwix',
+        'description': _('Daemon which provide Wikipedia on lan')},
+    {'name': 'ntp', 'description': _('Net time protocol')},
+    {'name': 'ssh',
+        'description': _('Daemon used for distant connexion to server')},
+]

--- a/ideasbox/conf/bwagiriza.py
+++ b/ideasbox/conf/bwagiriza.py
@@ -1,0 +1,4 @@
+"""Bwagiriza box in Burundi"""
+from .base import *
+IDEASBOX_NAME = "Bwagiriza"
+AUTH_USER_MODEL = 'ideasbox.BurundiRefugeeUser'

--- a/ideasbox/conf/bwagiriza.py
+++ b/ideasbox/conf/bwagiriza.py
@@ -1,4 +1,4 @@
 """Bwagiriza box in Burundi"""
-from .base import *
+from .base import *  # noqa
 IDEASBOX_NAME = "Bwagiriza"
 AUTH_USER_MODEL = 'ideasbox.BurundiRefugeeUser'

--- a/ideasbox/conf/kavumu.py
+++ b/ideasbox/conf/kavumu.py
@@ -1,0 +1,4 @@
+"""Kavumu box in Burundi"""
+from .base import *
+IDEASBOX_NAME = "Kavumu"
+AUTH_USER_MODEL = 'ideasbox.BurundiRefugeeUser'

--- a/ideasbox/conf/kavumu.py
+++ b/ideasbox/conf/kavumu.py
@@ -1,4 +1,4 @@
 """Kavumu box in Burundi"""
-from .base import *
+from .base import *  # noqa
 IDEASBOX_NAME = "Kavumu"
 AUTH_USER_MODEL = 'ideasbox.BurundiRefugeeUser'

--- a/ideasbox/conf/makamba.py
+++ b/ideasbox/conf/makamba.py
@@ -1,4 +1,4 @@
 """Makamba box in Burundi"""
-from .base import *
+from .base import *  # noqa
 IDEASBOX_NAME = "Makamba"
 AUTH_USER_MODEL = 'ideasbox.BurundiMakambaUser'

--- a/ideasbox/conf/makamba.py
+++ b/ideasbox/conf/makamba.py
@@ -1,0 +1,4 @@
+"""Makamba box in Burundi"""
+from .base import *
+IDEASBOX_NAME = "Makamba"
+AUTH_USER_MODEL = 'ideasbox.BurundiMakambaUser'

--- a/ideasbox/conf/musasa.py
+++ b/ideasbox/conf/musasa.py
@@ -1,0 +1,4 @@
+"""Musasa box in Burundi"""
+from .base import *
+IDEASBOX_NAME = "Musasa"
+AUTH_USER_MODEL = 'ideasbox.BurundiRefugeeUser'

--- a/ideasbox/conf/musasa.py
+++ b/ideasbox/conf/musasa.py
@@ -1,4 +1,4 @@
 """Musasa box in Burundi"""
-from .base import *
+from .base import *  # noqa
 IDEASBOX_NAME = "Musasa"
 AUTH_USER_MODEL = 'ideasbox.BurundiRefugeeUser'

--- a/ideasbox/management/commands/dummydata.py
+++ b/ideasbox/management/commands/dummydata.py
@@ -13,10 +13,9 @@ class Command(BaseCommand):
     help = 'Populate database with dummy data'
 
     def handle(self, *args, **options):
-        if settings.IDEASBOX_ID != 'debugbox':
+        if not settings.DEBUG:
             msg = ('This does not seem to be a dev project. Aborting. You need'
-                   ' to be in DEBUG=True mode plus not having set any custom '
-                   'IDEASBOX_ID value.')
+                   ' to be in DEBUG=True')
             raise CommandError(msg)
 
         # Create some users.

--- a/ideasbox/models.py
+++ b/ideasbox/models.py
@@ -88,11 +88,9 @@ class AbstractUser(TimeStampedModel, AbstractBaseUser):
 
         def val(name):
             try:
-                val = getattr(self, 'get_{0}_display'.format(name))()
+                return getattr(self, 'get_{0}_display'.format(name))()
             except AttributeError:
-                val = getattr(self, name)
-
-            return val
+                return getattr(self, name)
 
         return {f.name: {'label': f.verbose_name, 'value': val(f.name)}
                 for f in fields}

--- a/ideasbox/settings.py
+++ b/ideasbox/settings.py
@@ -1,161 +1,25 @@
-"""
-Django settings for ideasbox project.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/1.7/topics/settings/
-
-For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.7/ref/settings/
-"""
-
+import importlib
 import os
+import socket
+import sys
 
-from django.utils.translation import ugettext_lazy as _
+# The normal scenario is that we use the hostname, but let's make it
+# overridable, this is useful for dev and debugging.
+IDEASBOX_ID = os.environ.get('IDEASBOX_ID', socket.gethostname())
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-PROJECT_DIR = os.path.join(BASE_DIR, 'ideasbox')
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '16exrv_@=2(za=oj$tj+l_^v#sbt83!=t#wz$s+1udfa04#vz!'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-TEMPLATE_DEBUG = True
-
-ALLOWED_HOSTS = []
-
-
-# Application definition
-
-INSTALLED_APPS = (
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'serveradmin',
-    'ideasbox',
-    'blog',
-    'library',
-)
-
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
-
-TEMPLATE_CONTEXT_PROCESSORS = (
-    "django.contrib.auth.context_processors.auth",
-    "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
-    "django.core.context_processors.media",
-    "django.core.context_processors.static",
-    "django.core.context_processors.tz",
-    "django.contrib.messages.context_processors.messages",
-    "ideasbox.context_processors.settings"
-)
-
-ROOT_URLCONF = 'ideasbox.urls'
-
-WSGI_APPLICATION = 'ideasbox.wsgi.application'
-
-TEMPLATE_DIRS = (
-    os.path.join(PROJECT_DIR, 'templates'),
-)
-LOGIN_REDIRECT_URL = 'index'
-LOGIN_URL = 'login'
-
-# Internationalization
-# https://docs.djangoproject.com/en/1.7/topics/i18n/
-
-LANGUAGE_CODE = 'en'
-
-TIME_ZONE = os.environ.get('TIME_ZONE', 'UTC')
-
-USE_I18N = True
-
-USE_L10N = True
-
-USE_TZ = True
-
-AVAILABLE_LANGUAGES = (
-    ('en', _('English')),
-    ('fr', _('French')),
-    ('ar', _('Arabic')),
-)
-
-SUPPORTED_LANGUAGES = os.environ.get('SUPPORTED_LANGUAGES', 'fr en ar').split()
-LANGUAGES = []
-for code, label in AVAILABLE_LANGUAGES:
-    if code in SUPPORTED_LANGUAGES:
-        LANGUAGES.append((code, label))
-
-LOCALE_PATHS = (
-    os.path.join(BASE_DIR, 'locale'),
-)
-
-# Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.7/howto/static-files/
-
-STATIC_URL = '/static/'
-MEDIA_URL = '/media/'
-
-
-# Ideas Box specifics
+# Every box will have some edge specific needs, such as a specific user model,
+# we manage this with per box settings, but we want those specific settings
+# to be versionned, for two reasons: easier to debug when there is no hidden
+# local config, and easier to manage code upgrade.
 try:
-    IDEASBOX_ID = os.environ['IDEASBOX_ID']
-except KeyError:
-    if DEBUG:
-        IDEASBOX_ID = 'debugbox'
-    else:
-        raise
-try:
-    STORAGE_ROOT = os.environ['DATASTORAGE']
-except KeyError:
-    if DEBUG:
-        try:
-            os.makedirs('storage/main')
-        except OSError:
-            pass
-        STORAGE_ROOT = os.path.join(BASE_DIR, 'storage')
-    else:
-        raise
-MEDIA_ROOT = os.path.join(STORAGE_ROOT, 'main')
-STATIC_ROOT = os.path.join(STORAGE_ROOT, 'static')  # TODO move out of backuped
-                                                    # storage
-AUTH_USER_MODEL = os.environ.get('AUTH_USER_MODEL', 'ideasbox.DefaultUser')
-IDEASBOX_NAME = os.environ.get('IDEASBOX_NAME', IDEASBOX_ID)
-
-# Database
-# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(MEDIA_ROOT, 'default.sqlite'),
-    }
-}
-
-SERVICES = [
-    {'name': 'apache2', 'description': _('Daemon which provide web content')},
-    {'name': 'bind9', 'description': _('Daemon which provide local DNS')},
-    {'name': 'kalite',
-        'description': _('Daemon which provide KhanAcademy on lan')},
-    {'name': 'kiwix',
-        'description': _('Daemon which provide Wikipedia on lan')},
-    {'name': 'ntp', 'description': _('Net time protocol')},
-    {'name': 'ssh',
-        'description': _('Daemon used for distant connexion to server')},
-]
+    sub = importlib.import_module(".conf." + IDEASBOX_ID, package="ideasbox")
+except ImportError:
+    from .conf import base as sub
+finally:
+    SETTINGS_MODULE = sub.__name__  # Make if available as a settings, to
+                                    # be able to display it in the admin
+    sys.stdout.write('Importing settings from %s\n' % SETTINGS_MODULE)
+    ldict = locals()
+    for k in sub.__dict__:
+        if k.isupper() and not k.startswith('__') or not k.endswith('__'):
+            ldict[k] = sub.__dict__[k]

--- a/ideasbox/settings.py
+++ b/ideasbox/settings.py
@@ -16,8 +16,8 @@ try:
 except ImportError:
     from .conf import base as sub
 finally:
-    SETTINGS_MODULE = sub.__name__  # Make if available as a settings, to
-                                    # be able to display it in the admin
+    SETTINGS_MODULE = sub.__name__  # Make it available as a settings, to
+                                    # be able to display it in the admin.
     sys.stdout.write('Importing settings from %s\n' % SETTINGS_MODULE)
     ldict = locals()
     for k in sub.__dict__:

--- a/ideasbox/templates/form-fullpage.html
+++ b/ideasbox/templates/form-fullpage.html
@@ -6,7 +6,7 @@
     <form method="POST" enctype="multipart/form-data">
         <div class="row">
                 <div class="col two-third">
-                    {% block title %}{% endblock title %}
+                    {% block heading %}{% endblock heading %}
                     {% csrf_token %}
                     {{ form.as_p }}
                 </div>

--- a/ideasbox/templates/ideasbox/user_detail.html
+++ b/ideasbox/templates/ideasbox/user_detail.html
@@ -1,9 +1,16 @@
-{% extends 'base.html' %}
+{% extends 'two-third-third.html' %}
 
-{% block content %}
-    {{ user_obj }}
+{% block twothird %}
+    <h2>{{ user_obj }}</h2>
+    {% for field in user_obj.public_fields.values %}
+        <p><strong>{{ field.label }}</strong> {{ field.value }}</p>
+    {% endfor %}
+{% endblock twothird %}
+{% block third %}
     {% if user.is_staff %}
-        <a href="{% url 'user_update' pk=user_obj.pk %}">Edit</a>
-        <a href="{% url 'user_delete' pk=user_obj.pk %}">Delete</a>
+    <ul class="card tinted admin">
+        <li><a href="{% url 'user_update' pk=user_obj.pk %}">Edit</a></li>
+        <li><a href="{% url 'user_delete' pk=user_obj.pk %}">Delete</a></li>
+    </ul>
     {% endif %}
-{% endblock content %}
+{% endblock third %}

--- a/ideasbox/templates/ideasbox/user_form.html
+++ b/ideasbox/templates/ideasbox/user_form.html
@@ -1,13 +1,13 @@
 {% extends 'form-fullpage.html' %}
 {% load i18n %}
 
-{% block title %}
+{% block heading %}
     {% if user_obj %}
         <h2>{% trans "Edit user" %} {{ user_obj }}</h2>
     {% else %}
         <h2>{% trans "New User" %}</h2>
     {% endif %}
-{% endblock title %}
+{% endblock heading %}
 {% block col %}
         <input type="submit" value="submit" />
 {% endblock col %}

--- a/ideasbox/tests/test_models.py
+++ b/ideasbox/tests/test_models.py
@@ -2,6 +2,7 @@ import pytest
 
 from django.contrib.auth import get_user_model
 
+from ..models import BurundiRefugeeUser
 from .factories import UserFactory
 
 pytestmark = pytest.mark.django_db
@@ -34,3 +35,16 @@ def test_create_superuser():
 
 def test_client_login(client, user):
     assert client.login(serial=user.serial, password='password')
+
+
+def test_user_public_fields_should_return_labels_and_values():
+    user = BurundiRefugeeUser(
+        short_name='my name',
+        school_level=1
+    )
+    fields = user.public_fields
+    assert 'is_staff' not in fields
+    assert fields['short_name']['value'] == 'my name'
+    assert fields['short_name']['label'] == 'usual name'
+    assert fields['school_level']['value'] == 'Primary'
+    assert fields['school_level']['label'] == 'School level'

--- a/library/templates/library/book_form.html
+++ b/library/templates/library/book_form.html
@@ -1,13 +1,13 @@
 {% extends 'form-fullpage.html' %}
 {% load i18n %}
 
-{% block title %}
+{% block heading %}
     {% if book %}
         <h2>{% trans "Edit book" %} "{{ book }}"</h2>
     {% else %}
         <h2>{% trans "New book" %}</h2>
     {% endif %}
-{% endblock title %}
+{% endblock heading %}
 {% block col %}
     <input type="submit" value="{% trans 'submit' %}" />
     {% if book %}

--- a/library/templates/library/specimen_form.html
+++ b/library/templates/library/specimen_form.html
@@ -1,13 +1,13 @@
 {% extends 'form-fullpage.html' %}
 {% load i18n %}
 
-{% block title %}
+{% block heading %}
     {% if specimen %}
         <h2>{% trans "Edit book specimen" %} "{{ specimen }}"</h2>
     {% else %}
         <h2>{% trans "New book specimen" %}</h2>
     {% endif %}
-{% endblock title %}
+{% endblock heading %}
 {% block col %}
     <input type="submit" value="{% trans 'submit' %}" />
     {% if specimen %}


### PR DESCRIPTION
This PR also:

- fixes model mixins that was not inheriting from `models.Model`, so fields was not active
- fixes `form-fullpage.html` template that was overriding `title` block
- introduces a `user.public_fields` method, allowing to loop over user fields, even with a custom user model

If it's better, I can split this into other PRs. :)