### PR TITLE
Add lang switcher in footer (fix #56)

### DIFF
--- a/blog/tests/test_views.py
+++ b/blog/tests/test_views.py
@@ -96,8 +96,8 @@ def test_staff_should_access_deleted_edit_page(staffapp, deleted):
 
 
 def test_staff_can_edit_published_content(staffapp, published):
-    form = staffapp.get(reverse('blog:content_update',
-                                kwargs={'pk': published.pk})).form
+    url = reverse('blog:content_update', kwargs={'pk': published.pk})
+    form = staffapp.get(url).forms['model_form']
     title = "New title"
     assert Content.objects.get(pk=published.pk).title != title
     form['title'] = title
@@ -106,8 +106,8 @@ def test_staff_can_edit_published_content(staffapp, published):
 
 
 def test_staff_can_edit_draft_content(staffapp, draft):
-    form = staffapp.get(reverse('blog:content_update',
-                                kwargs={'pk': draft.pk})).form
+    url = reverse('blog:content_update', kwargs={'pk': draft.pk})
+    form = staffapp.get(url).forms['model_form']
     title = "New title"
     assert Content.objects.get(pk=draft.pk).title != title
     form['title'] = title
@@ -116,8 +116,8 @@ def test_staff_can_edit_draft_content(staffapp, draft):
 
 
 def test_staff_can_edit_delete_content(staffapp, deleted):
-    form = staffapp.get(reverse('blog:content_update',
-                                kwargs={'pk': deleted.pk})).form
+    url = reverse('blog:content_update', kwargs={'pk': deleted.pk})
+    form = staffapp.get(url).forms['model_form']
     title = "New title"
     assert Content.objects.get(pk=deleted.pk).title != title
     form['title'] = title
@@ -127,7 +127,7 @@ def test_staff_can_edit_delete_content(staffapp, deleted):
 
 def test_can_create_content_without_image(staffapp):
     assert not Content.objects.count()
-    form = staffapp.get(reverse('blog:content_create')).form
+    form = staffapp.get(reverse('blog:content_create')).forms['model_form']
     form['title'] = 'my content title'
     form['summary'] = 'my content summary'
     form['text'] = 'my content text'

--- a/ideasbox/conf/base.py
+++ b/ideasbox/conf/base.py
@@ -61,6 +61,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "django.contrib.auth.context_processors.auth",
     "django.core.context_processors.debug",
     "django.core.context_processors.i18n",
+    "django.core.context_processors.request",
     "django.core.context_processors.media",
     "django.core.context_processors.static",
     "django.core.context_processors.tz",

--- a/ideasbox/static/ideasbox/main.css
+++ b/ideasbox/static/ideasbox/main.css
@@ -313,7 +313,7 @@ html[dir='rtl'] .boxid {
     float: left;
     right: -31px;
 }
-div.i18n_switch select {
+.i18n_switch select {
     display: inline;
     width: calc(100% - 100px);
     margin: 0;
@@ -322,7 +322,7 @@ div.i18n_switch select {
     vertical-align: top;
     height: 40px;
 }
-div.i18n_switch input[type='submit'] {
+.i18n_switch input[type='submit'] {
     display: inline;
     width: 100px;
     border-bottom-left-radius: 0;

--- a/ideasbox/static/ideasbox/main.css
+++ b/ideasbox/static/ideasbox/main.css
@@ -313,7 +313,33 @@ html[dir='rtl'] .boxid {
     float: left;
     right: -31px;
 }
-
+div.i18n_switch select {
+    display: inline;
+    width: calc(100% - 100px);
+    margin: 0;
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+    vertical-align: top;
+    height: 40px;
+}
+div.i18n_switch input[type='submit'] {
+    display: inline;
+    width: 100px;
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    margin: 0;
+    vertical-align: top;
+    height: 40px;
+    line-height: 40px;
+}
+html[dir='rtl'] .i18n_switch select {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+}
+html[dir='rtl'] .i18n_switch input[type='submit'] {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+}
 
 /* ************************************************* */
 /* ******************** TOOLS ********************** */

--- a/ideasbox/templates/form-fullpage.html
+++ b/ideasbox/templates/form-fullpage.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <form method="POST" enctype="multipart/form-data">
+    <form method="POST" enctype="multipart/form-data" id="model_form">
         <div class="row">
                 <div class="col two-third">
                     {% block heading %}{% endblock heading %}

--- a/ideasbox/templates/ideasbox/form_confirm_delete.html
+++ b/ideasbox/templates/ideasbox/form_confirm_delete.html
@@ -7,6 +7,6 @@
     <form method="POST" action="." id="delete_form">
         {% csrf_token %}
         {{ form.as_p }}
-        <input type="submit" name="confirm" value="{% trans 'yes' %}" />
+        <p><input type="submit" name="confirm" value="{% trans 'yes' %}" /></p>
     </form>
 {% endblock row %}

--- a/ideasbox/templates/ideasbox/form_confirm_delete.html
+++ b/ideasbox/templates/ideasbox/form_confirm_delete.html
@@ -1,0 +1,12 @@
+{% extends 'one-row.html' %}
+{% load i18n %}
+
+{% block row %}
+    <h2>{% block confirm_message %}{% endblock %}</h2>
+    <p>{% block confirm_warning %}{% endblock %}</p>
+    <form method="POST" action="." id="delete_form">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <input type="submit" name="confirm" value="{% trans 'yes' %}" />
+    </form>
+{% endblock row %}

--- a/ideasbox/templates/ideasbox/includes/footer.html
+++ b/ideasbox/templates/ideasbox/includes/footer.html
@@ -1,21 +1,39 @@
-{% load i18n %}
+{% load i18n ideasbox_tags %}
 
+{% spaceless %}
 <footer>
     <div class="row">
-        <ul class="col third">Ideas Box
+        <ul class="col quarter">Ideas Box
             <li><a href="#">Blog</a></li>
             <li><a href="#">Library</a></li>
             <li><a href="#">Contents</a></li>
         </ul>
-        <ul class="col third">Site Administration
+        <ul class="col quarter">Site Administration
             <li><a href="{% url 'user_list' %}">Manage members</a></li>
             <li><a href="#">Manage blog</a></li>
             <li><a href="#">Manage library</a></li>
         </ul>
-        <ul class="col third">Server Administration
+        <ul class="col quarter">Server Administration
             <li><a href="{% url 'server:services' %}">{% trans "Manage services" %}</a></li>
             <li><a href="{% url 'server:power' %}">{% trans "Restart server" %}</a></li>
             <li><a href="#">Backup / restore</a></li>
         </ul>
+        <div class="col quarter i18n_switch">
+            <form action="{% url 'set_language' %}" method="post">
+                {% csrf_token %}
+                {# Next should not contain the i18n prefix, otherwise it will change again lang to current one after redirect. #}
+                <input name="next" type="hidden" value="{{ request.path|remove_i18n }}" />
+                <select name="language">
+                {% get_language_info_list for LANGUAGES as languages %}
+                {% for language in languages %}
+                    <option value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} selected="selected"{% endif %}>
+                    {{ language.name_local }} ({{ language.code }})
+                    </option>
+                {% endfor %}
+                </select>
+                <input type="submit" value="{% trans 'Change' %}" />
+            </form>
+        </div>
     </div>
 </footer>
+{% endspaceless %}

--- a/ideasbox/templates/ideasbox/user_confirm_delete.html
+++ b/ideasbox/templates/ideasbox/user_confirm_delete.html
@@ -1,11 +1,4 @@
-{% extends 'one-row.html' %}
+{% extends 'ideasbox/form_confirm_delete.html' %}
 {% load i18n %}
 
-{% block row %}
-    <h2>{% blocktrans %}Are you sure you want to delete user "{{ user_obj }}"?{% endblocktrans %}</h2>
-    <form method="POST" action=".">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <input type="submit" name="confirm" value="{% trans 'yes' %}" />
-    </form>
-{% endblock row %}
+{% block confirm_message %}{% blocktrans %}Are you sure you want to delete user "{{ user_obj }}"?{% endblocktrans %}{% endblock %}

--- a/ideasbox/templatetags/ideasbox_tags.py
+++ b/ideasbox/templatetags/ideasbox_tags.py
@@ -26,8 +26,10 @@ def theme_slug(inst, slug=None):
     return mark_safe(tpl.format(klass=klass, slug=slug))
 
 
+i18n_pattern = re.compile(language_code_prefix_re)
+
+
 @register.filter()
 def remove_i18n(url):
     """Remove i18n prefix from an URL."""
     return i18n_pattern.sub("/", url)
-i18n_pattern = re.compile(language_code_prefix_re)

--- a/ideasbox/templatetags/ideasbox_tags.py
+++ b/ideasbox/templatetags/ideasbox_tags.py
@@ -1,5 +1,8 @@
+import re
+
 from django import template
 from django.utils.safestring import mark_safe
+from django.utils.translation.trans_real import language_code_prefix_re
 
 register = template.Library()
 
@@ -21,3 +24,10 @@ def theme_slug(inst, slug=None):
         slug = SLUGS.get(name, name.lower())
     klass = THEMES.get(name, slug)
     return mark_safe(tpl.format(klass=klass, slug=slug))
+
+
+@register.filter()
+def remove_i18n(url):
+    """Remove i18n prefix from an URL."""
+    return i18n_pattern.sub("/", url)
+i18n_pattern = re.compile(language_code_prefix_re)

--- a/ideasbox/tests/test_templatetags.py
+++ b/ideasbox/tests/test_templatetags.py
@@ -3,7 +3,7 @@ import pytest
 from blog.tests.factories import ContentFactory
 from library.tests.factories import BookFactory
 
-from ..templatetags.ideasbox_tags import theme_slug
+from ..templatetags.ideasbox_tags import theme_slug, remove_i18n
 
 pytestmark = pytest.mark.django_db
 
@@ -21,3 +21,11 @@ def test_theme_slug_for_book():
 def test_theme_slug_can_be_overrided():
     book = BookFactory()
     assert theme_slug(book, "xxx") == '<span class="theme read">xxx</span>'
+
+
+@pytest.mark.parametrize('given,expected', [
+    ['/', '/'],
+    ['/en/xxxx/', '/xxxx/'],
+])
+def test_remove_i18n(given, expected):
+    assert remove_i18n(given) == expected

--- a/ideasbox/tests/test_views.py
+++ b/ideasbox/tests/test_views.py
@@ -51,12 +51,12 @@ def test_login_page_should_not_log_in_user_with_incorrect_POST(client, user):
 
 def test_user_list_page_should_be_accessible(app, user):
     response = app.get(reverse('user_list'))
-    assert unicode(user) in response.content
+    response.mustcontain(unicode(user))
 
 
 def test_user_detail_page_should_be_accessible(app, user):
     response = app.get(reverse('user_detail', kwargs={'pk': user.pk}))
-    assert unicode(user) in response.content
+    response.mustcontain(unicode(user))
 
 
 def test_user_create_page_should_not_be_accessible_to_anonymous(app):
@@ -74,7 +74,7 @@ def test_user_create_page_should_be_accessible_to_staff(staffapp):
 def test_should_create_user_with_serial_only(staffapp):
     assert len(user_model.objects.all()) == 1
     serial = '12345xz22'
-    form = staffapp.get(reverse('user_create')).form
+    form = staffapp.get(reverse('user_create')).forms['model_form']
     form['serial'] = serial
     form.submit()
     assert len(user_model.objects.all()) == 2
@@ -83,7 +83,7 @@ def test_should_create_user_with_serial_only(staffapp):
 
 def test_should_not_create_user_without_serial(staffapp):
     assert len(user_model.objects.all()) == 1
-    form = staffapp.get(reverse('user_create')).form
+    form = staffapp.get(reverse('user_create')).forms['model_form']
     form.submit()
     assert len(user_model.objects.all()) == 1
 
@@ -106,7 +106,7 @@ def test_staff_should_be_able_to_update_user(staffapp, user):
     assert len(user_model.objects.all()) == 2
     url = reverse('user_update', kwargs={'pk': user.pk})
     short_name = 'Denis'
-    form = staffapp.get(url).form
+    form = staffapp.get(url).forms['model_form']
     form['serial'] = user.serial
     form['short_name'] = short_name
     form.submit().follow()
@@ -116,7 +116,7 @@ def test_staff_should_be_able_to_update_user(staffapp, user):
 
 def test_should_not_update_user_without_serial(app, staffapp, user):
     url = reverse('user_update', kwargs={'pk': user.pk})
-    form = staffapp.get(url).form
+    form = staffapp.get(url).forms['model_form']
     form['serial'] = ''
     form['short_name'] = 'ABCDEF'
     assert form.submit()
@@ -156,6 +156,6 @@ def test_non_staff_cannot_delete_user(loggedapp, user):
 def test_staff_user_can_delete_user(staffapp, user):
     assert len(user_model.objects.all()) == 2  # staff user and normal user
     url = reverse('user_delete', kwargs={'pk': user.pk})
-    form = staffapp.get(url).form
+    form = staffapp.get(url).forms['delete_form']
     form.submit()
     assert len(user_model.objects.all()) == 1

--- a/ideasbox/urls.py
+++ b/ideasbox/urls.py
@@ -24,4 +24,4 @@ urlpatterns = i18n_patterns('',
     url(r'^user/(?P<pk>[\d]+)/delete/$',
         views.user_delete, name='user_delete'),
 
-) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) + [url(r'^i18n/', include('django.conf.urls.i18n')),]

--- a/library/templates/library/book_confirm_delete.html
+++ b/library/templates/library/book_confirm_delete.html
@@ -1,11 +1,4 @@
-{% extends 'one-row.html' %}
+{% extends 'ideasbox/form_confirm_delete.html' %}
 {% load i18n %}
 
-{% block row %}
-    <h2>{% blocktrans %}Are you sure you want to delete book "{{ book }}" and all its specimens?{% endblocktrans %}</h2>
-    <form method="POST">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <input type="submit" name="confirm" value="{% trans 'yes' %}" />
-    </form>
-{% endblock row %}
+{% block confirm_message %}{% blocktrans %}Are you sure you want to delete book "{{ book }}" and all its specimens?{% endblocktrans %}{% endblock %}

--- a/library/templates/library/specimen_confirm_delete.html
+++ b/library/templates/library/specimen_confirm_delete.html
@@ -1,12 +1,5 @@
-{% extends 'one-row.html' %}
+{% extends 'ideasbox/form_confirm_delete.html' %}
 {% load i18n %}
 
-{% block row %}
-    <h2>{% blocktrans with name=specimen %}Are you sure you want to delete "{{ name }}"?{% endblocktrans %}</h2>
-    <p>{% blocktrans with name=specimen.book %}This will not delete book "{{ name }}"{% endblocktrans %}</p>
-    <form method="POST">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <input type="submit" name="confirm" value="{% trans 'yes' %}" />
-    </form>
-{% endblock row %}
+{% block confirm_message %}{% blocktrans with name=specimen %}Are you sure you want to delete "{{ name }}"?{% endblocktrans %}{% endblock %}
+{% block confirm_warning %}{% blocktrans with name=specimen.book %}This will not delete book "{{ name }}"{% endblocktrans %}{% endblock %}

--- a/library/tests/test_views.py
+++ b/library/tests/test_views.py
@@ -87,7 +87,7 @@ def test_staff_should_access_book_update_page(staffapp, book):
 
 
 def test_staff_can_create_book(staffapp):
-    form = staffapp.get(reverse('library:book_create')).form
+    form = staffapp.get(reverse('library:book_create')).forms['model_form']
     assert not Book.objects.count()
     form['title'] = 'My book title'
     form['summary'] = 'My book summary'
@@ -98,7 +98,7 @@ def test_staff_can_create_book(staffapp):
 
 def test_staff_can_edit_book(staffapp, book):
     form = staffapp.get(reverse('library:book_update',
-                                kwargs={'pk': book.pk})).form
+                                kwargs={'pk': book.pk})).forms['model_form']
     title = "New title"
     assert Book.objects.get(pk=book.pk).title != title
     form['title'] = title
@@ -109,14 +109,14 @@ def test_staff_can_edit_book(staffapp, book):
 def test_staff_user_can_delete_book(staffapp, book):
     assert Book.objects.count() == 1
     url = reverse('library:book_delete', kwargs={'pk': book.pk})
-    form = staffapp.get(url).form
+    form = staffapp.get(url).forms['delete_form']
     form.submit()
     assert not Book.objects.count()
 
 
 def test_staff_can_create_specimen(staffapp, book):
     url = reverse('library:specimen_create', kwargs={'book_pk': book.pk})
-    form = staffapp.get(url).form
+    form = staffapp.get(url).forms['model_form']
     assert not book.specimens.count()
     form['serial'] = '23135321'
     form.submit().follow()
@@ -124,8 +124,8 @@ def test_staff_can_create_specimen(staffapp, book):
 
 
 def test_staff_can_edit_specimen(staffapp, specimen):
-    form = staffapp.get(reverse('library:specimen_update',
-                                kwargs={'pk': specimen.pk})).form
+    url = reverse('library:specimen_update', kwargs={'pk': specimen.pk})
+    form = staffapp.get(url).forms['model_form']
     remarks = "This is a new remark"
     assert BookSpecimen.objects.get(pk=specimen.pk).remarks != remarks
     form['remarks'] = remarks
@@ -137,7 +137,7 @@ def test_staff_user_can_delete_specimen(staffapp, specimen):
     assert BookSpecimen.objects.count() == 1
     assert Book.objects.count() == 1
     url = reverse('library:specimen_delete', kwargs={'pk': specimen.pk})
-    form = staffapp.get(url).form
+    form = staffapp.get(url).forms['delete_form']
     form.submit()
     assert Book.objects.count() == 1
     assert not BookSpecimen.objects.count()
@@ -146,13 +146,13 @@ def test_staff_user_can_delete_specimen(staffapp, specimen):
 def test_it_should_be_possible_to_create_several_books_without_isbn(staffapp):
     assert not Book.objects.count()
     url = reverse('library:book_create')
-    form = staffapp.get(url).form
+    form = staffapp.get(url).forms['model_form']
     form['title'] = 'My book title'
     form['summary'] = 'My book summary'
     form['section'] = '1'
     form['isbn'] = ''
     form.submit().follow()
-    form = staffapp.get(url).form
+    form = staffapp.get(url).forms['model_form']
     form['title'] = 'My book title 2'
     form['summary'] = 'My book summary 2'
     form['section'] = '2'
@@ -166,11 +166,11 @@ def test_it_should_be_possible_to_remove_isbn_from_books(staffapp):
     book2 = BookFactory(isbn='321564987')
     assert not Book.objects.filter(isbn__isnull=True)
     form = staffapp.get(reverse('library:book_update',
-                        kwargs={'pk': book1.pk})).form
+                        kwargs={'pk': book1.pk})).forms['model_form']
     form['isbn'] = ''
     form.submit().follow()
     form = staffapp.get(reverse('library:book_update',
-                        kwargs={'pk': book2.pk})).form
+                        kwargs={'pk': book2.pk})).forms['model_form']
     form['isbn'] = ''
     form.submit().follow()
     assert len(Book.objects.filter(isbn__isnull=True)) == 2

--- a/search/templates/search/box.html
+++ b/search/templates/search/box.html
@@ -2,7 +2,7 @@
 
 {% spaceless %}
 <div class="card tinted search">
-    <form action="{% url "search:search" %}">
+    <form action="{% url "search:search" %}" id="search">
         <input name="q" type="text" placeholder="{% trans 'search' %}" value="{{ q }}" />
         <input type="submit" value="{% trans 'search' %}" />
     </form>

--- a/search/tests/test_views.py
+++ b/search/tests/test_views.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.django_db
 
 def test_search_view_should_show_results(app):
     content = ContentFactory(title='test content', status=Content.PUBLISHED)
-    form = app.get(reverse('search:search')).form
+    form = app.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
     assert content.title in page.content
@@ -19,7 +19,7 @@ def test_search_view_should_show_results(app):
 
 def test_search_view_should_not_return_draft_content_to_anonymous(app):
     content = ContentFactory(title='test content', status=Content.DRAFT)
-    form = app.get(reverse('search:search')).form
+    form = app.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
     assert content.title not in page.content
@@ -27,7 +27,7 @@ def test_search_view_should_not_return_draft_content_to_anonymous(app):
 
 def test_search_view_should_not_return_deleted_content_to_anonymous(app):
     content = ContentFactory(title='test content', status=Content.DELETED)
-    form = app.get(reverse('search:search')).form
+    form = app.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
     assert content.title not in page.content
@@ -35,7 +35,7 @@ def test_search_view_should_not_return_deleted_content_to_anonymous(app):
 
 def test_search_view_should_not_return_draft_content_to_logged_user(loggedapp):
     content = ContentFactory(title='test content', status=Content.DRAFT)
-    form = loggedapp.get(reverse('search:search')).form
+    form = loggedapp.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
     assert content.title not in page.content
@@ -43,7 +43,7 @@ def test_search_view_should_not_return_draft_content_to_logged_user(loggedapp):
 
 def test_search_view_should_not_return_deleted_to_logged_user(loggedapp):
     content = ContentFactory(title='test content', status=Content.DELETED)
-    form = loggedapp.get(reverse('search:search')).form
+    form = loggedapp.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
     assert content.title not in page.content
@@ -51,7 +51,7 @@ def test_search_view_should_not_return_deleted_to_logged_user(loggedapp):
 
 def test_search_view_should_return_draft_content_to_staff_user(staffapp):
     content = ContentFactory(title='test content', status=Content.DRAFT)
-    form = staffapp.get(reverse('search:search')).form
+    form = staffapp.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
     assert content.title in page.content
@@ -59,7 +59,7 @@ def test_search_view_should_return_draft_content_to_staff_user(staffapp):
 
 def test_search_view_should_not_return_deleted_to_staff_user(staffapp):
     content = ContentFactory(title='test content', status=Content.DELETED)
-    form = staffapp.get(reverse('search:search')).form
+    form = staffapp.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
     assert content.title in page.content
@@ -68,7 +68,7 @@ def test_search_view_should_not_return_deleted_to_staff_user(staffapp):
 def test_search_view_should_return_mixed_content(app):
     content = ContentFactory(title='test content', status=Content.PUBLISHED)
     book = BookFactory(title='test book')
-    form = app.get(reverse('search:search')).form
+    form = app.get(reverse('search:search')).forms['search']
     form['q'] = 'test'
     page = form.submit()
     assert content.title in page.content


### PR DESCRIPTION
Ref: #56

This PR just adds a select lang switcher in the footer, but there are two tricks:
- firstly, as it adds a form in every page, I've needed to add ids to every form, in order to make them selectable in unittests, which create a lot of noise in the diff
- secondly, as we are using i18n URLs, we needed to workaround a limitation of the Django view: if we just give the current URL as "next" parameter, it will never work, because the URL contains the i18n prefix (for example `/en/`, so the Django view will set the new lang, then redirect to the next URL, which contains the i19n prefix, so will be caught by the i18n middleware, which at its turn will set the current language (so using the initial language)