### PR TITLE
Added python-pytest to build-depends.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: ideasbox
 Section: python
 Priority: extra
 Maintainer: Yohan Boniface <hi@yohanboniface.me>
-Build-Depends: debhelper (>= 9), python, dh-virtualenv (>= 0.7)
+Build-Depends: debhelper (>= 9), python, dh-virtualenv (>= 0.6), python-pytest
 Standards-Version: 3.9.5
 
 Package: ideasbox


### PR DESCRIPTION
This change allows to build cleanly on an Ubuntu trusty PPA (trusty has dh-virtualenv 0.6.1)