### PR TITLE
Fix service getter clashing with status key

### DIFF
--- a/ideasbox/conf/base.py
+++ b/ideasbox/conf/base.py
@@ -169,7 +169,7 @@ SERVICES = [
     {
         'name': 'kalite',
         'description': _('Daemon which provides KhanAcademy on lan'),
-        'status': lambda x: {'status': False} if subprocess.call(['pgrep', 'kalite', '-f']) else {'status': True}  # noqa
+        'call_status': lambda x: {'status': False} if subprocess.call(['pgrep', 'kalite', '-f']) else {'status': True}  # noqa
     },
     {'name': 'kiwix',
         'description': _('Daemon which provides Wikipedia on lan')},

--- a/ideasbox/conf/base.py
+++ b/ideasbox/conf/base.py
@@ -169,7 +169,7 @@ SERVICES = [
     {
         'name': 'kalite',
         'description': _('Daemon which provides KhanAcademy on lan'),
-        'call_status': lambda x: {'status': False} if subprocess.call(['pgrep', 'kalite', '-f']) else {'status': True}  # noqa
+        'status_caller': lambda x: {'status': False} if subprocess.call(['pgrep', 'kalite', '-f']) else {'status': True}  # noqa
     },
     {'name': 'kiwix',
         'description': _('Daemon which provides Wikipedia on lan')},

--- a/ideasbox/serveradmin/tests/test_views.py
+++ b/ideasbox/serveradmin/tests/test_views.py
@@ -53,7 +53,7 @@ def test_should_override_service_action_caller(staffapp, settings):
     spy = MagicMock()
     settings.SERVICES = [{'name': 'xxxx', 'status_caller': spy}]
     assert staffapp.get(reverse("server:services"), status=200)
-    assert spy.called
+    assert spy.call_count == 1
 
 
 def test_staff_user_should_access_power_admin(staffapp):

--- a/ideasbox/serveradmin/tests/test_views.py
+++ b/ideasbox/serveradmin/tests/test_views.py
@@ -3,6 +3,7 @@ import zipfile
 
 import pytest
 from webtest.forms import Upload
+from mock import MagicMock
 
 from django.core.urlresolvers import reverse
 from django.core.files.base import ContentFile
@@ -46,6 +47,13 @@ def test_staff_user_should_access_services(monkeypatch, staffapp):
 
     monkeypatch.setattr("subprocess.Popen", Mock)
     assert staffapp.get(reverse("server:services"), status=200)
+
+
+def test_should_override_service_action_caller(staffapp, settings):
+    spy = MagicMock()
+    settings.SERVICES = [{'name': 'xxxx', 'status_caller': spy}]
+    assert staffapp.get(reverse("server:services"), status=200)
+    assert spy.called
 
 
 def test_staff_user_should_access_power_admin(staffapp):

--- a/ideasbox/serveradmin/views.py
+++ b/ideasbox/serveradmin/views.py
@@ -31,7 +31,9 @@ def services(request):
             service['action'] = service_action
         else:
             service['action'] = 'status'
-        caller = 'call_{action}'.format(**service)
+        # The way to run the action may be overrided in the service definition
+        # in the settings.
+        caller = '{action}_caller'.format(**service)
         if caller in service:
             status = service[caller](service)
         else:

--- a/ideasbox/serveradmin/views.py
+++ b/ideasbox/serveradmin/views.py
@@ -31,8 +31,9 @@ def services(request):
             service['action'] = service_action
         else:
             service['action'] = 'status'
-        if service['action'] in service:
-            status = service[service['action']](service)
+        caller = 'call_{action}'.format(**service)
+        if caller in service:
+            status = service[caller](service)
         else:
             status = call_service(service)
         service['error'] = status.get('error')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 django-webtest==1.7.7
 factory-boy==2.4.1
+mock==1.0.1
 pyquery==1.2.9
 pytest==2.6.4
 pytest-django==2.8.0


### PR DESCRIPTION
When defining a service in settings, it's possible to override the way to interact the service, this was clashing with the `status` key.