### PR TITLE
CONTRIBUTING.md contains contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to ideasbox.lan
+
+Do you like to make the ideasbox.lan project better? Welcome! This document
+will try to provide guidelines about what and how you can help.
+
+
+## Contact and resources
+
+If you have any question, problem or idea, feel free to get in touch with
+project's maintainers:
+
+* Chat using #ideasbox channel on Freenode. If you are not familiar with
+  [IRC](https://en.wikipedia.org/wiki/Internet_Relay_Chat), you can try
+  this simple [online chat application](https://kiwiirc.com/client/irc.freenode.net/?nick=new-user|?#ideasbox):
+  just click "Start" then chat!
+
+* Ask questions, report issues or propose ideas as
+  [tickets] (https://github.com/issues).
+
+Here are online resources you may find useful to contribute to the project:
+
+* Homepage: http://www.ideas-box.org/
+* Code repository: https://github.com/ideas-box/ideasbox.lan
+* Issues, questions and feature requests:
+  https://github.com/ideas-box/ideasbox.lan/issues
+* Continuous integration: https://travis-ci.org/ideas-box/ideasbox.lan
+* Documentation:
+
+  * docs: https://github.com/ideas-box/ideasbox.lan/blob/master/docs/index.md
+  * wiki: https://github.com/ideas-box/ideasbox.lan/wiki
+
+
+## How can I give a hand?
+
+* Join the brainstorming: report or comment issues; edit wiki; join IRC chan
+* Review [pull requests](https://github.com/ideas-box/ideasbox.lan/pulls)
+* Take an [issue](https://github.com/ideas-box/ideasbox.lan/issues) and code :)
+* What about a sprint?
+
+
+## Installing for development
+
+### System setup
+
+You need python 2.7 installed.
+
+Install system dependencies:
+
+    sudo apt-get install python-pip python-virtualenv virtualenvwrapper
+
+Create a virtualenv (we name it `ideasbox` here but the name is up to you):
+
+    mkvirtualenv ideasbox
+
+Install python dependencies:
+
+    make devinstall
+
+
+### Project setup
+
+Run the initial database migration::
+
+    python manage.py migrate
+
+To populate the database with some initial dummy data, you can run the command::
+
+    python manage.py dummydata

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,7 @@ Here are online resources you may find useful to contribute to the project:
 * Issues, questions and feature requests:
   https://github.com/ideas-box/ideasbox.lan/issues
 * Continuous integration: https://travis-ci.org/ideas-box/ideasbox.lan
-* Documentation:
-
-  * docs: https://github.com/ideas-box/ideasbox.lan/blob/master/docs/index.md
-  * wiki: https://github.com/ideas-box/ideasbox.lan/wiki
+* Documentation: https://github.com/ideas-box/ideasbox.lan/blob/master/docs/index.md
 
 
 ## How can I give a hand?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ project's maintainers:
   just click "Start" then chat!
 
 * Ask questions, report issues or propose ideas as
-  [tickets] (https://github.com/issues).
+  [tickets](https://github.com/issues).
 
 Here are online resources you may find useful to contribute to the project:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,15 +38,29 @@ Here are online resources you may find useful to contribute to the project:
 * What about a sprint?
 
 
-## Installing for development
+## Install ideasbox.lan for development
 
-### System setup
+### Setup system
 
-You need python 2.7 installed.
+Project's typical development environment requires:
 
-Install system dependencies:
+* [Python 2.7](https://www.python.org/)
+* [Git](http://git-scm.com/)
+
+On a Debian-based system, you may use:
 
     sudo apt-get install python-pip python-virtualenv virtualenvwrapper
+
+### Download the souce code
+
+Get project's source code from
+[project's code repository](https://github.com/ideas-box/ideasbox.lan)
+(you may use your own fork):
+
+    git clone git@github.com:ideas-box/ideasbox.lan.git
+    cd ideasbox.lan/
+
+### Setup project
 
 Create a virtualenv (we name it `ideasbox` here but the name is up to you):
 
@@ -56,13 +70,22 @@ Install python dependencies:
 
     make devinstall
 
-
-### Project setup
-
 Run the initial database migration::
 
     python manage.py migrate
 
 To populate the database with some initial dummy data, you can run the command::
 
-    python manage.py dummydata
+    make dummydata
+
+### Check and run!
+
+Run the server:
+
+    python manage.py runserver
+
+Check it works:
+
+    firefox http://localhost:8000
+
+Done!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,10 +46,12 @@ Project's typical development environment requires:
 
 * [Python 2.7](https://www.python.org/)
 * [Git](http://git-scm.com/)
+* JPEG development headers (for Pillow).
 
 On a Debian-based system, you may use:
 
     sudo apt-get install python-pip python-virtualenv virtualenvwrapper
+python-dev libjpeg-dev
 
 ### Download the souce code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,7 @@ Project's typical development environment requires:
 
 On a Debian-based system, you may use:
 
-    sudo apt-get install python-pip python-virtualenv virtualenvwrapper
-python-dev libjpeg-dev
+    sudo apt-get install python-pip python-virtualenv virtualenvwrapper python-dev libjpeg-dev
 
 ### Download the souce code
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,25 @@ This Django repository is the main application of the Ideas Box server.
 
 More about the Ideas Box concept: http://www.ideas-box.org/
 
-More details about the server of the [overview](https://github.com/ideas-box/ideasbox.lan/wiki/Server-Overview)
+More details about the server in the [overview](https://github.com/ideas-box/ideasbox.lan/wiki/Server-Overview).
 
 ## How can I give a hand?
 
-* Join the brainstorming: read and comment issues and wiki; join the #ideasbox chan on Freenode
-* Review [pull requests](https://github.com/ideas-box/ideasbox.lan/pulls)
-* Take an [issue](https://github.com/ideas-box/ideasbox.lan/issues) and code :)
-* What about a sprint ?
+Welcome! There are many ways you can help. See details in
+[contributor guide](https://github.com/ideas-box/ideasbox.lan/CONTRIBUTING.md).
 
-## IRC
+## Resources and contacts
 
-`#ideasbox` on `irc.freenode.net`
+* Homepage: http://www.ideas-box.org/
+* IRC chat: `#ideasbox` on `irc.freenode.net`. If you are not familiar with
+  [IRC](https://en.wikipedia.org/wiki/Internet_Relay_Chat), you can try
+  this simple [online chat application](https://kiwiirc.com/client/irc.freenode.net/?nick=new-user|?#ideasbox).
+* Contributor guide: https://github.com/ideas-box/ideasbox.lan/CONTRIBUTING.md
+* Code repository: https://github.com/ideas-box/ideasbox.lan
+* Issues, questions and feature requests:
+  https://github.com/ideas-box/ideasbox.lan/issues
+* Continuous integration: https://travis-ci.org/ideas-box/ideasbox.lan
+* Documentation:
+
+  * docs: https://github.com/ideas-box/ideasbox.lan/blob/master/docs/index.md
+  * wiki: https://github.com/ideas-box/ideasbox.lan/wiki

--- a/README.md
+++ b/README.md
@@ -24,7 +24,4 @@ Welcome! There are many ways you can help. See details in
 * Issues, questions and feature requests:
   https://github.com/ideas-box/ideasbox.lan/issues
 * Continuous integration: https://travis-ci.org/ideas-box/ideasbox.lan
-* Documentation:
-
-  * docs: https://github.com/ideas-box/ideasbox.lan/blob/master/docs/index.md
-  * wiki: https://github.com/ideas-box/ideasbox.lan/wiki
+* Documentation: https://github.com/ideas-box/ideasbox.lan/blob/master/docs/index.md

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,14 @@
 # Installation
 
+**Here are instructions to run a production environment**, i.e. tasks to
+deploy, run and use an ideasbox.lan server.
+
+**If you want to setup a development environment**, as an example in order to
+contribute to the project, please see [Contributor guide]
+(https://github.com/ideas-box/ideasbox.lan/CONTRIBUTING.md).
+
+
+## System setup
 
 You need python 2.7 installed.
 
@@ -7,34 +16,16 @@ Install system dependencies:
 
     sudo apt-get install python-pip python-virtualenv virtualenvwrapper
 
-
 Create a virtualenv (we name it `ideasbox` here but the name is up to you):
 
     mkvirtualenv ideasbox
 
-
 Install python dependencies:
 
     make install  # for production
-    # or
-    make devinstall  # for hacking on the code
-
 
 
 ## Project setup
-
-### Dev setup
-
-Run the initial database migration::
-
-    python manage.py migrate
-
-To populate the database with some initial dummy data, you can run the command::
-
-    python manage.py dummydata
-
-
-### Production setup
 
 First, build the `.deb`:
 
@@ -51,4 +42,3 @@ Run the initial database migration:
 Create an administrator:
 
     sudo ideasbox createsuperuser
-


### PR DESCRIPTION
Here is a proposal around documentation for contributors.

Here are planned changes:

* [x] CONTRIBUTING.md provides contributor's documentation. It doesn't have to be complete and perfect in this pull-request: could be improved by future pull-requests.
* [x] separate "production" and "development" documentation. As an example, docs/install.md focuses on production setup, whereas CONTRIBUTING.md focuses on development environment.
* [x] README and CONTIBUTING list project's online resources , i.e. issues, continuous integration, roadmap, documentation...
* [x] In freshly installed development environment using CONTRIBUTING.md, tests pass.