### PR TITLE
README mentions license and links to LICENSE file.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,9 @@
+# Authors and contributors
+
+ideasbox.lan is owned and maintained by
+[Bibliothèques Sans Frontières](http://www.bibliosansfrontieres.org/), and
+published under the terms of MIT license (see
+[LICENSE.md](https://github.com/ideas-box/ideasbox.lan/blob/master/LICENSE.md)).
+
+See also contributors on [Github
+repository](https://github.com/ideas-box/ideasbox.lan/graphs/contributors).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# License
+
+Copyright (c) 2015 BSF IT Team <it@bibliosansfrontieres.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ More about the Ideas Box concept: http://www.ideas-box.org/
 
 More details about the server of the [overview](https://github.com/ideas-box/ideasbox.lan/wiki/Server-Overview)
 
+[ideasbox.lan is free software, published under the terms of MIT license](https://github.com/ideas-box/ideasbox.lan/LICENSE.md).
+
 ## How can I give a hand?
 
 * Join the brainstorming: read and comment issues and wiki; join the #ideasbox chan on Freenode


### PR DESCRIPTION
setup.py already has "license" but LICENSE file was missing. Added it. Mentioned it in README.

Can you check license, date and copyright holder?