### PR TITLE
Adds two packages (libxml2-dev libxslt1-dev) to dependencies.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Project's typical development environment requires:
 
 On a Debian-based system, you may use:
 
-    sudo apt-get install python-pip python-virtualenv virtualenvwrapper python-dev libjpeg-dev
+    sudo apt-get install python-pip python-virtualenv virtualenvwrapper python-dev libjpeg-dev libxml2-dev libxslt1-dev
 
 ### Download the souce code
 


### PR DESCRIPTION
To execute without errors "make devinstall" I had to install these additionnal packages. Installing 'libxml2-dev' only wasn't enough.

It may be because I'm running an old 12.04 ubuntu desktop.

The log message is here:
https://zerobin.net/?1b0815e147ec6d05#WNN8th4y3K9FUGEHGUBakUo2KqzN5l3tJHzmQXEi25s=
